### PR TITLE
Fixes out-of-memory errors when using lots of subrequests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,12 @@ New:
 
 Fixes:
 
-- *add item here*
+- When a subrequest modified the DB (or prior to the subrequest the main request),
+  the oids annotated to the requests were doubled with each subsequent subrequest.
+  This resulted in out-of-memory errors when using lots of subrequests,
+  such as it happens on Mosaic based sites with a certain amount of tiles.
+  Fixed by only adding new oids, not already known by parent request.
+  [jensens]
 
 
 1.6.11 (2015-09-07)

--- a/plone/subrequest/__init__.py
+++ b/plone/subrequest/__init__.py
@@ -156,8 +156,11 @@ def subrequest(url, root=None, stdout=None):
             # append this list of safe oids to parent request
             if SAFE_WRITE_KEY not in parent_request.environ:
                 parent_request.environ[SAFE_WRITE_KEY] = []
-            parent_request.environ[SAFE_WRITE_KEY].extend(
-                request.environ[SAFE_WRITE_KEY])
+            new_keys = (
+                set(request.environ[SAFE_WRITE_KEY]) -
+                set(parent_request.environ[SAFE_WRITE_KEY])
+            )
+            parent_request.environ[SAFE_WRITE_KEY].extend(new_keys)
         if IDisableCSRFProtection.providedBy(request):
             alsoProvides(parent_request, IDisableCSRFProtection)
         request.clear()


### PR DESCRIPTION
When a subrequest modified the DB (or prior to the subrequest the main request), the oids annotated to the requests were doubled with each subsequent subrequest.

This resulted in out-of-memory errors when using lots of subrequests,  such as it happens on Mosaic based sites with a cerain amount of sites.

Fixed by only adding oids not already known by parent request.
