### PR TITLE
Allow to pass a custom exception handler for the response.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-1.6.12 (unreleased)
--------------------
+1.7.0 (unreleased)
+------------------
 
 New:
 
-- *add item here*
+- Allow to pass a custom exception handler for the response.
+  [jensens]
 
 Fixes:
 

--- a/plone/subrequest/__init__.py
+++ b/plone/subrequest/__init__.py
@@ -68,7 +68,7 @@ OTHER_IGNORE_RE = re.compile(r'^(?:BASE|URL)\d+$')
 logger = getLogger('plone.subrequest')
 
 
-def subrequest(url, root=None, stdout=None):
+def subrequest(url, root=None, stdout=None, exception_handler=None):
     assert url is not None, 'You must pass a url'
     if isinstance(url, unicode):
         url = url.encode('utf-8')
@@ -156,9 +156,12 @@ def subrequest(url, root=None, stdout=None):
                 response.setBody(result)
             for key, value in request.response.cookies.items():
                 parent_request.response.cookies[key] = value
-        except Exception:
+        except Exception, e:
             logger.exception('Error handling subrequest to {0}'.format(url))
-            response.exception()
+            if exception_handler is not None:
+                exception_handler(response, e)
+            else:
+                response.exception()
         return response
     finally:
         if SAFE_WRITE_KEY in request.environ:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os.path
 
 
-version = '1.6.12.dev0'
+version = '1.7.0.dev0'
 
 setup(
     name='plone.subrequest',


### PR DESCRIPTION
This change allows a caller of a subrequest to provide a custom exception handler.
This adds a new feature but has zero effect for existing callers.