### PR TITLE
Update __init__.py (remove virtual-url-parts from path)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove vurl-parts from path
+  [awello]
 
 
 1.8.1 (2017-06-28)

--- a/plone/subrequest/__init__.py
+++ b/plone/subrequest/__init__.py
@@ -89,6 +89,7 @@ def subrequest(url, root=None, stdout=None, exception_handler=None):
             root_path = normpath(
                 parent_request['PATH_INFO']
             ).rstrip('/')[:-len(path_past_root) or None]
+            path = path.replace(vurl_parts[1], '', 1)
             if root is None:
                 path = root_path + path
             else:


### PR DESCRIPTION
this patch is needed for rewrites like `http://HOST:PORT/VirtualHostBase/https/my_address:443/path/to/plone/VirtualHostRoot/_vh_myshortcut` 
the virtual-url-parts have to be removed from the path (if not you have urls like `myshortcut/_vh_myshortcut` )