### PR TITLE
Remove five.globalrequest dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Remove five.globalrequest dependency.
+  It has been deprecated upstream (on Zope 4).
+  [gforcada]
 
 New features:
 

--- a/plone/subrequest/configure.zcml
+++ b/plone/subrequest/configure.zcml
@@ -1,3 +1,2 @@
 <configure xmlns="http://namespaces.zope.org/zope">
-    <include package="five.globalrequest" />
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     zip_safe=False,
     install_requires=[
         # 'Acquisition',
-        'five.globalrequest',
         'setuptools',
         'six',
         'zope.globalrequest',

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,6 @@ setup(
     classifiers=[
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: 4.3",
-        "Framework :: Plone :: 5.0",
-        "Framework :: Plone :: 5.1",
         "Framework :: Plone :: 5.2",
         "Framework :: Zope2",
         "Intended Audience :: Developers",


### PR DESCRIPTION
On Zope 4 is already merge into Zope itself.