### PR TITLE
Revert Python 3 and Zope 4 changes on 1.8.x branch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,12 @@ Changelog
 1.8.7 (unreleased)
 ------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
 Bug fixes:
 
-- *add item here*
+- Restored to 1.8.4 version.  Kept only the optional Archetypes test dependency.
+  Plone 4.3, 5,0 and 5.1 do not need the Python 3 and Zope 4 fixes, and may give errors.
+  Plone 5.2 does not use this branch.
+  Fixes `issue 2995 <https://github.com/plone/Products.CMFPlone/issues/2995>`_.  [maurits]
 
 
 1.8.6 (2018-09-23)

--- a/plone/subrequest/subresponse.py
+++ b/plone/subrequest/subresponse.py
@@ -2,9 +2,6 @@
 from ZPublisher.HTTPResponse import HTTPResponse
 from ZPublisher.Iterators import IStreamIterator
 
-import io
-import six
-
 
 try:
     from plone.app.blob.iterators import BlobStreamIterator
@@ -16,7 +13,7 @@ except ImportError:
 class SubResponse(HTTPResponse):
 
     def setBody(self, body, title='', is_error=0, **kw):
-        """Accept either a stream iterator or a string as the body."""
+        """ Accept either a stream iterator or a string as the body """
         if not IStreamIterator.providedBy(body):
             return HTTPResponse.setBody(self, body, title, is_error, **kw)
         assert not self._wrote
@@ -30,7 +27,7 @@ class SubResponse(HTTPResponse):
             return
         try:
             while True:
-                chunk = next(body)
+                chunk = body.next()
                 self.write(chunk)
         except StopIteration:
             pass
@@ -39,20 +36,13 @@ class SubResponse(HTTPResponse):
         return str(self.body)
 
     def outputBody(self):
-        """Output the response body."""
+        """Output the response body"""
         if not self._wrote:
-            body = self.body
-            if isinstance(self.stdout, io.BufferedIOBase)\
-                    and isinstance(body, six.text_type):
-                body = body.encode('utf-8')
-            elif isinstance(self.stdout, io.TextIOBase)\
-                    and isinstance(body, six.binary_type):
-                body = body.decode('utf-8')
-            self.stdout.write(body)
+            self.stdout.write(self.body)
             self._wrote = 1
 
     def getBody(self):
-        """Return the body, however it was written."""
+        """ Return the body, however it was written. """
         if not self._wrote:
             return self.body
         stdout = self.stdout

--- a/plone/subrequest/testing.py
+++ b/plone/subrequest/testing.py
@@ -8,8 +8,6 @@ from plone.testing import zodb
 from Products.Five.browser import BrowserView
 from zope.globalrequest import setRequest
 
-import six
-
 
 class CustomException(Exception):
     """Custom exception"""
@@ -18,7 +16,7 @@ class CustomException(Exception):
 class CustomExceptionHandler(BrowserView):
     def __call__(self):
         self.request.response.setStatus(500)
-        return "Custom exception occurred: {0}".format(self.context)
+        return "Custom exception occurred: {0:s}".format(self.context)
 
 
 class CookieView(BrowserView):
@@ -42,6 +40,8 @@ class URLView(BrowserView):
 
     def __call__(self):
         url = self.context.absolute_url()
+        # The absolute url is expected to be an encoded string, not unicode.
+        assert isinstance(url, str)
         return url
 
 

--- a/plone/subrequest/tests.py
+++ b/plone/subrequest/tests.py
@@ -9,19 +9,7 @@ from zope.site.hooks import getSite
 import manuel.doctest
 import manuel.testcase
 import manuel.testing
-
-import doctest
-import re
-import six
 import unittest
-
-
-try:
-    from ZServer.HTTPResponse import ZServerHTTPResponse
-except ImportError:
-    HAS_ZSERVER = False
-else:
-    HAS_ZSERVER = True
 
 
 try:
@@ -41,7 +29,7 @@ def traverse(url):
 
 
 VH_TPL = (
-    '/VirtualHostBase/http/nohost:80/{0}/VirtualHostRoot'
+    '/VirtualHostBase/http/example.org:80/{0}/VirtualHostRoot'
     '/_vh_fizz/_vh_buzz/_vh_fizzbuzz/{1}'
 )
 NOHOST_VH_TPL = 'http://nohost' + VH_TPL
@@ -61,7 +49,7 @@ class FunctionalTests(unittest.TestCase):
         parts = ('folder1', 'folder1A/@@url')
         expect = 'folder1A'
         url = NOHOST_VH_TPL.format(*parts)
-        expect_url = 'http://nohost/fizz/buzz/fizzbuzz/{0}'.format(expect)
+        expect_url = 'http://example.org/fizz/buzz/fizzbuzz/{0}'.format(expect)
         self.browser.open(url)
         self.assertEqual(self.browser.contents, expect_url)
 
@@ -69,7 +57,7 @@ class FunctionalTests(unittest.TestCase):
         parts = ('folder1', 'folder1A?url=folder1Ai/@@url')
         expect = 'folder1A/folder1Ai'
         url = NOHOST_VH_TPL.format(*parts)
-        expect_url = 'http://nohost/fizz/buzz/fizzbuzz/{0}'.format(expect)
+        expect_url = 'http://example.org/fizz/buzz/fizzbuzz/{0}'.format(expect)
         self.browser.open(url)
         self.assertEqual(self.browser.contents, expect_url)
 
@@ -77,7 +65,7 @@ class FunctionalTests(unittest.TestCase):
         parts = ('folder1', 'folder1A?url=/folder1B/@@url')
         expect = 'folder1B'
         url = NOHOST_VH_TPL.format(*parts)
-        expect_url = 'http://nohost/fizz/buzz/fizzbuzz/{0}'.format(expect)
+        expect_url = 'http://example.org/fizz/buzz/fizzbuzz/{0}'.format(expect)
         self.browser.open(url)
         self.assertEqual(self.browser.contents, expect_url)
 
@@ -89,14 +77,14 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest('/folder1/@@url')
         self.assertEqual(
             response.body,
-            b'http://nohost/folder1'
+            'http://nohost/folder1'
         )
 
     def test_absolute_query(self):
         response = subrequest('/folder1/folder1A?url=/folder2/folder2A/@@url')
         self.assertEqual(
             response.body,
-            b'http://nohost/folder2/folder2A'
+            'http://nohost/folder2/folder2A'
         )
 
     def test_relative(self):
@@ -104,14 +92,14 @@ class IntegrationTests(unittest.TestCase):
         # /folder1 resolves to /folder1/@@test
         self.assertEqual(
             response.body,
-            b'http://nohost/folder1/folder1B'
+            'http://nohost/folder1/folder1B'
         )
 
     def test_root(self):
         response = subrequest('/')
         self.assertEqual(
             response.body,
-            b'Root: http://nohost'
+            'Root: http://nohost'
         )
 
     def test_virtual_hosting(self):
@@ -119,7 +107,7 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest(url)
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/buzz/fizzbuzz/folder1A'
+            'http://example.org/fizz/buzz/fizzbuzz/folder1A'
         )
 
     def test_virtual_hosting_unicode(self):
@@ -127,7 +115,7 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest(url)
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/buzz/fizzbuzz/folder1A'
+            'http://example.org/fizz/buzz/fizzbuzz/folder1A'
         )
 
     def test_virtual_hosting_relative(self):
@@ -135,7 +123,7 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest(url)
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/buzz/fizzbuzz/folder1B'
+            'http://example.org/fizz/buzz/fizzbuzz/folder1B'
         )
 
     def test_not_found(self):
@@ -149,7 +137,7 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest('/folder1B/@@url')
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/buzz/fizzbuzz/folder1B'
+            'http://example.org/fizz/buzz/fizzbuzz/folder1B'
         )
 
     def test_virtual_host_root_with_root(self):
@@ -160,13 +148,13 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest('/folder1Ai/@@url', root=app.folder1.folder1A)
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/buzz/fizzbuzz/folder1A/folder1Ai'
+            'http://example.org/fizz/buzz/fizzbuzz/folder1A/folder1Ai'
         )
 
     def test_virtual_host_space(self):
         parts = ('folder2', 'folder2A/folder2Ai space/@@url')
         url = (
-            '/VirtualHostBase/http/nohost:80/'
+            '/VirtualHostBase/http/example.org:80/'
             '{0}/VirtualHostRoot/{1}'.format(*parts)
         )
         traverse(url)
@@ -174,36 +162,36 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest('/folder2A/@@url', root=app.folder2)
         self.assertEqual(
             response.body,
-            b'http://nohost/folder2A'
+            'http://example.org/folder2A'
         )
 
     def test_virtual_host_root_at_root(self):
         url = (
-            '/VirtualHostBase/http/nohost:80/folder1/VirtualHostRoot/'
+            '/VirtualHostBase/http/example.org:80/folder1/VirtualHostRoot/'
             '_vh_fizz/_vh_buzz/_vh_fizzbuzz'
         )
         traverse(url)
         response = subrequest('/folder1B/@@url')
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/buzz/fizzbuzz/folder1B'
+            'http://example.org/fizz/buzz/fizzbuzz/folder1B'
         )
 
     def test_virtual_host_root_at_root_trailing(self):
         url = (
-            '/VirtualHostBase/http/nohost:80/folder1/VirtualHostRoot/'
+            '/VirtualHostBase/http/example.org:80/folder1/VirtualHostRoot/'
             '_vh_fizz/_vh_buzz/_vh_fizzbuzz/'
         )
         traverse(url)
         response = subrequest('/folder1B/@@url')
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/buzz/fizzbuzz/folder1B'
+            'http://example.org/fizz/buzz/fizzbuzz/folder1B'
         )
 
     def test_virtual_host_with_root_double_slash(self):
         url = (
-            '/VirtualHostBase/http/nohost:80/VirtualHostRoot/'
+            '/VirtualHostBase/http/example.org:80/VirtualHostRoot/'
             '_vh_fizz/folder1/folder2//folder2A'
         )
         traverse(url)
@@ -211,7 +199,7 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest('/folder1B/@@url', root=root)
         self.assertEqual(
             response.body,
-            b'http://nohost/fizz/folder1/folder1B'
+            'http://example.org/fizz/folder1/folder1B'
         )
 
     def test_subrequest_root(self):
@@ -219,7 +207,7 @@ class IntegrationTests(unittest.TestCase):
         response = subrequest('/folder1Ai/@@url', root=app.folder1.folder1A)
         self.assertEqual(
             response.body,
-            b'http://nohost/folder1/folder1A/folder1Ai'
+            'http://nohost/folder1/folder1A/folder1Ai'
         )
 
     def test_site(self):
@@ -232,29 +220,29 @@ class IntegrationTests(unittest.TestCase):
 
     def test_parameter(self):
         response = subrequest('/folder1/@@parameter?foo=bar')
-        self.assertTrue(b'foo' in response.body)
+        self.assertTrue('foo' in response.body)
 
     def test_cookies(self):
         request = getRequest()
         request.response.setCookie('cookie_name', 'cookie_value')
         response = subrequest('/folder1/@@parameter')
-        self.assertTrue(b"'cookie_name'" in response.body)
+        self.assertTrue("'cookie_name'" in response.body)
 
     def test_subrequest_cookies(self):
         response = subrequest('/folder1/@@test?url=/folder1/cookie')
         self.assertTrue('cookie_name' in response.cookies)
 
-    @unittest.skipUnless(HAS_ZSERVER, 'needs ZServer')
     def test_stream_iterator(self):
         # Only a ZServerHTTPResponse is IStreamIterator Aware
+        from ZServer.HTTPResponse import ZServerHTTPResponse
         request = getRequest()
         request.response.__class__ = ZServerHTTPResponse
         response = subrequest('/@@stream')
         self.assertEqual(response.getBody(), 'hello')
 
-    @unittest.skipUnless(HAS_ZSERVER, 'needs ZServer')
     def test_filestream_iterator(self):
         # Only a ZServerHTTPResponse is IStreamIterator Aware
+        from ZServer.HTTPResponse import ZServerHTTPResponse
         request = getRequest()
         request.response.__class__ = ZServerHTTPResponse
         response = subrequest('/@@filestream')
@@ -262,10 +250,10 @@ class IntegrationTests(unittest.TestCase):
         self.assertTrue(isinstance(response.stdout, filestream_iterator))
         self.assertEqual(response.getBody(), 'Test')
 
-    @unittest.skipUnless(HAS_ZSERVER, 'needs ZServer')
     @unittest.skipUnless(HAS_BLOBSTREAM_ITERATOR, 'requires Archetypes')
     def test_blobstream_iterator(self):
         # Only a ZServerHTTPResponse is IStreamIterator Aware
+        from ZServer.HTTPResponse import ZServerHTTPResponse
         request = getRequest()
         request.response.__class__ = ZServerHTTPResponse
         response = subrequest('/@@blobstream')
@@ -279,27 +267,20 @@ class IntegrationTests(unittest.TestCase):
         request['VIRTUAL_URL'] = 'parent'
         request['URL9'] = 'parent'
         response = subrequest('/folder1/@@parameter')
-        self.assertTrue(b"'foo'" in response.body)
-        self.assertFalse(b"'URL9'" in response.body)
-        self.assertFalse(b"'VIRTUAL_URL'" in response.body)
-
-
-class Py23DocChecker(doctest.OutputChecker):
-    def check_output(self, want, got, optionflags):
-        if six.PY2:
-            want = re.sub("b'(.*?)'", "'\\1'", want)
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
+        self.assertTrue("'foo'" in response.body)
+        self.assertFalse("'URL9'" in response.body)
+        self.assertFalse("'VIRTUAL_URL'" in response.body)
 
 
 def test_suite():
     suite = unittest.defaultTestLoader.loadTestsFromName(__name__)
-    m = manuel.doctest.Manuel(checker=Py23DocChecker())
+    m = manuel.doctest.Manuel()
     m += manuel.testcase.MarkerManuel()
     doctests = manuel.testing.TestSuite(
         m,
-        'usage.rst',
+        'usage.txt',
         globs=dict(subrequest=subrequest, traverse=traverse)
-     )
+    )
     # Set the layer on the manuel doctests for now
     for test in doctests:
         test.layer = INTEGRATION_TESTING

--- a/plone/subrequest/usage.txt
+++ b/plone/subrequest/usage.txt
@@ -11,12 +11,11 @@ Call ``subrequest(url)``, it returns a response object.
     >>> from plone.subrequest import subrequest
     >>> response = subrequest('/folder1/@@url')
     >>> response.getBody()
-    b'http://nohost/folder1'
+    'http://nohost/folder1'
 
 .. test-case: response-write
 
 ``response.getBody()`` also works for code that calls ``response.write(data)``.
-This one returns a text/non-byte value.
 
     >>> response = subrequest('/@@response-write')
     >>> response.getBody()
@@ -40,8 +39,7 @@ Some code may call ``response.write(data)``.
 
 In which case you may access response.stdout as file.
 
-    >>> response.stdout.seek(0, 0) or 0  # Py2 returns None, Py3 returns new position
-    0
+    >>> response.stdout.seek(0, 0)
     >>> list(response.stdout)
     ['Some data.\n', 'Some more data.\n']
 
@@ -64,8 +62,7 @@ Use ``response.outputBody()`` to ensure the body may be accessed as a file.
     >>> response.outputBody()
     >>> response._wrote
     1
-    >>> response.stdout.seek(0, 0) or 0  # Py2 returns None, Py3 returns new position
-    0
+    >>> response.stdout.seek(0, 0)
     >>> list(response.stdout)
     ['http://nohost/folder1']
 
@@ -76,11 +73,10 @@ Relative paths
 
 Relative paths are resolved relative to the parent request's location:
 
-    >>> from plone.subrequest.tests import traverse
     >>> request = traverse('/folder1/@@test')
     >>> response = subrequest('folder1A/@@url')
     >>> response.getBody()
-    b'http://nohost/folder1/folder1A'
+    'http://nohost/folder1/folder1A'
 
 .. test-case: relative-default-view
 
@@ -91,7 +87,7 @@ This takes account of default view's url.
     True
     >>> response = subrequest('folder1A/@@url')
     >>> response.getBody()
-    b'http://nohost/folder1/folder1A'
+    'http://nohost/folder1/folder1A'
 
 Virtual hosting
 ---------------
@@ -100,10 +96,10 @@ Virtual hosting
 
 When virtual hosting is used, absolute paths are traversed from the virtual host root.
 
-    >>> request = traverse('/VirtualHostBase/http/nohost:80/folder1/VirtualHostRoot/')
+    >>> request = traverse('/VirtualHostBase/http/example.org:80/folder1/VirtualHostRoot/')
     >>> response = subrequest('/folder1A/@@url')
     >>> response.getBody()
-    b'http://nohost/folder1A'
+    'http://example.org/folder1A'
 
 Specifying the root
 -------------------
@@ -115,7 +111,7 @@ You may also set the root object explicitly
     >>> app = layer['app']
     >>> response = subrequest('/folder1A/@@url', root=app.folder1)
     >>> response.getBody()
-    b'http://nohost/folder1/folder1A'
+    'http://nohost/folder1/folder1A'
 
 Error responses
 ---------------
@@ -142,7 +138,7 @@ Or might raise an error rendered by a custom error view.
     >>> response.status
     500
     >>> response.body
-    b'Custom exception occurred: A custom error'
+    'Custom exception occurred: A custom error'
 
 .. test-case: status-ok
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description='Subrequests for Zope2',
     long_description=(
         open("README.rst").read() + "\n\n" +
-        open(os.path.join('plone', 'subrequest', 'usage.rst')).read() +
+        open(os.path.join('plone', 'subrequest', 'usage.txt')).read() +
         "\n\n" +
         open("CHANGES.rst").read()),
     classifiers=[
@@ -27,8 +27,8 @@ setup(
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.6",
     ],
     keywords='plone',
     author='Plone Foundation',
@@ -44,7 +44,6 @@ setup(
         # 'Acquisition',
         'five.globalrequest',
         'setuptools',
-        'six',
         'zope.globalrequest',
         ],
     extras_require={
@@ -55,6 +54,7 @@ setup(
         ],
         'archetypes': [
             'plone.app.blob',
+
             # see https://github.com/plone/plone.app.blob/issues/19
             'Products.MimetypesRegistry',
         ],


### PR DESCRIPTION
This basically restores 1.8.x to the 1.8.4 version. I keep only the optional Archetypes test dependency, plus minor changes, like removing `bootstrap.py`.

Reason for the revert: Plone 4.3, 5,0 and 5.1 do not need the Python 3 and Zope 4 fixes, and they give errors in some cases. Plone 5.2 does not use this branch.
This fixes https://github.com/plone/Products.CMFPlone/issues/2995.

The best way to review is probably to checkout the branch and do `git diff 1.8.4`. In this PR I tried to make that diff small.