### PR TITLE
Fixed deprecation warning for zope.site.hooks

### DIFF
--- a/news/24.bugfix
+++ b/news/24.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for zope.site.hooks.
+[maurits]

--- a/plone/subrequest/__init__.py
+++ b/plone/subrequest/__init__.py
@@ -12,11 +12,11 @@ from six.moves.urllib.parse import unquote
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlsplit
 from zope.component import queryMultiAdapter
+from zope.component.hooks import getSite
+from zope.component.hooks import setSite
 from zope.globalrequest import getRequest
 from zope.globalrequest import setRequest
 from zope.interface import alsoProvides
-from zope.site.hooks import getSite
-from zope.site.hooks import setSite
 from ZPublisher.BaseRequest import RequestContainer
 from ZPublisher.mapply import mapply
 


### PR DESCRIPTION
```
DeprecationWarning: zope.site.hooks has moved to zope.component.hooks. Import of zope.site.hooks will become unsupported in Version 5.0
```