### PR TITLE
Config with default template

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/master/config/default
 [meta]
 template = "default"
-commit-id = "49620d68"
+commit-id = "13d8d6c0"
 
 [dependencies]
 mappings = [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+ci:
+    autofix_prs: false
+    autoupdate_schedule: monthly
+
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/collective/zpretty
+    rev: 3.0.2
+    hooks:
+    -   id: zpretty
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+    -   id: codespell
+        additional_dependencies:
+          - tomli
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: "0.49"
+    hooks:
+    -   id: check-manifest
+-   repo: https://github.com/regebro/pyroma
+    rev: "4.2"
+    hooks:
+    -   id: pyroma

--- a/news/13d8d6c0.internal
+++ b/news/13d8d6c0.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/plone/subrequest/testing.zcml
+++ b/plone/subrequest/testing.zcml
@@ -1,81 +1,82 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:zcml="http://namespaces.zope.org/zcml">
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    >
 
-    <include package="plone.subrequest" />
+  <include package="plone.subrequest" />
 
-    <browser:page
-        name="cookie"
-        for="*"
-        class="plone.subrequest.testing.CookieView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="cookie"
+      for="*"
+      class="plone.subrequest.testing.CookieView"
+      permission="zope.Public"
+      />
 
-    <browser:page
-        name="parameter"
-        for="*"
-        class="plone.subrequest.testing.ParameterView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="parameter"
+      for="*"
+      class="plone.subrequest.testing.ParameterView"
+      permission="zope.Public"
+      />
 
-    <browser:page
-        name="url"
-        for="*"
-        class="plone.subrequest.testing.URLView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="url"
+      for="*"
+      class="plone.subrequest.testing.URLView"
+      permission="zope.Public"
+      />
 
-    <browser:page
-        name="response-write"
-        for="*"
-        class="plone.subrequest.testing.ResponseWriteView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="response-write"
+      for="*"
+      class="plone.subrequest.testing.ResponseWriteView"
+      permission="zope.Public"
+      />
 
-    <browser:page
-        name="error"
-        for="*"
-        class="plone.subrequest.testing.ErrorView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="error"
+      for="*"
+      class="plone.subrequest.testing.ErrorView"
+      permission="zope.Public"
+      />
 
-    <browser:page
-        name="root"
-        for="OFS.Application.Application"
-        class="plone.subrequest.testing.RootView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="root"
+      for="OFS.Application.Application"
+      class="plone.subrequest.testing.RootView"
+      permission="zope.Public"
+      />
 
-    <browser:page
-        name="test"
-        for="*"
-        class="plone.subrequest.testing.SubrequestView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="test"
+      for="*"
+      class="plone.subrequest.testing.SubrequestView"
+      permission="zope.Public"
+      />
 
-    <browser:defaultView
-        for="OFS.Folder.Folder"
-        name="test"
-        />
+  <browser:defaultView
+      name="test"
+      for="OFS.Folder.Folder"
+      />
 
-    <browser:defaultView
-        for="OFS.Application.Application"
-        name="root"
-        />
+  <browser:defaultView
+      name="root"
+      for="OFS.Application.Application"
+      />
 
-    <browser:page
-        name="custom-error"
-        for="*"
-        class="plone.subrequest.testing.CustomErrorView"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="custom-error"
+      for="*"
+      class="plone.subrequest.testing.CustomErrorView"
+      permission="zope.Public"
+      />
 
-    <browser:page
-        name="index.html"
-        for="plone.subrequest.testing.CustomException"
-        class="plone.subrequest.testing.CustomExceptionHandler"
-        permission="zope.Public"
-        />
+  <browser:page
+      name="index.html"
+      for="plone.subrequest.testing.CustomException"
+      class="plone.subrequest.testing.CustomExceptionHandler"
+      permission="zope.Public"
+      />
 
 </configure>

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,5 +19,6 @@ ignore =
 ignore =
     .editorconfig
     .meta.toml
+    .pre-commit-config.yaml
     tox.ini
     lint-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,47 +4,47 @@
 envlist =
     format
     lint
+    test
 
 [testenv]
-py_files = git ls-files "*.py"
-text_files = git ls-files "*.rst" "*.md"
 allowlist_externals =
     sh
 
 [testenv:format]
-description = automatically reformat python code
+description = automatically reformat code
 skip_install = true
 deps =
-    pyupgrade
-    isort
-    black
-    -c lint-requirements.txt
+    pre-commit
 commands =
-    sh -c '{[testenv]py_files} | xargs pyupgrade --py38-plus'
-    sh -c '{[testenv]py_files} | xargs isort'
-    sh -c '{[testenv]py_files} | xargs black'
+    pre-commit run -a pyupgrade
+    pre-commit run -a isort
+    pre-commit run -a black
+    pre-commit run -a zpretty
 
 [testenv:lint]
 description = run linters that will help improve the code style
 skip_install = true
 deps =
-    flake8
-    codespell
-    tomli  # needed for codespell to read pyproject.toml
-    check-manifest
-    pyroma
-    -c lint-requirements.txt
+    pre-commit
 commands =
-    sh -c '{[testenv]py_files} | xargs flake8'
-    sh -c '{[testenv]py_files} | xargs codespell'
-    sh -c '{[testenv]text_files} | xargs codespell'
-    check-manifest
-    pyroma -n 10 .
+    pre-commit run -a
 
 [testenv:dependencies]
-description = check if the package defines all its dependencies
+description = check if the package defines all its dependencies and generate a graph out of them
 deps =
-    z3c.dependencychecker
-    -c lint-requirements.txt
+    z3c.dependencychecker==2.11
+    pipdeptree==2.5.1
+    graphviz  # optional dependency of pipdeptree
 commands =
     dependencychecker
+    sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
+
+[testenv:test]
+usedevelop = true
+deps =
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    zope-testrunner --test-path={toxinidir} -s plone.subrequest
+extras =
+    test

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,8 @@ commands =
 usedevelop = true
 deps =
     zope.testrunner
+    plone.portlets  # undeclared dependency of plone.protect
+    Products.CMFCore  # undeclared dependency of plone.protect
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
     zope-testrunner --test-path={toxinidir} -s plone.subrequest


### PR DESCRIPTION
With tests enabled 🎉 

Unfortunately, `plone.protect` does not declare its dependency on `Products.CMFCore` nor on `plone.portlets`, so I depend on them on the `tox.ini` environment to be able to run the tests.